### PR TITLE
license(us-ca): caltrain, bart, capitol corridor, santa cruz, vta

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -163,6 +163,36 @@
       "url": "https://github.com/user-attachments/files/24483097/Response.-.26-FOI-00215.pdf"
     },
     {
+      "identifier": "ca-vta-terms",
+      "name": "Valley Transportion Authority Terms",
+      "attribution_text": null,
+      "url": "https://web.archive.org/web/20190704044857/http://www.vta.org/getting-around/gtfs-info/dev-terms-of-use"
+    },
+    {
+      "identifier": "ca-sfmta-terms",
+      "name": "SFMTA Terms",
+      "attribution_text": "Reproduced with permission granted by the City and County of San Francisco. The information has been provided by means of a nonexclusive, limited, and revocable license granted by the City and County of San Francisco. The City and County of San Francisco does not guarantee the accuracy, adequacy, completeness or usefulness of any information. The City and County of San Francisco provides this information \"as is,\" without warranty of any kind, express or implied, including but not limited to warranties of merchantability or fitness for a particular purpose, and assumes no responsibility for anyone's use of the information.",
+      "url": "https://www.sfmta.com/reports/gtfs-transit-data"
+    },
+    {
+      "identifier": "ca-bart-terms",
+      "name": "BART Terms",
+      "attribution_text": null,
+      "url": "https://www.bart.gov/schedules/developers/developer-license-agreement"
+    },
+    {
+      "identifier": "ca-caltrain-terms",
+      "name": "Caltrain Terms",
+      "attribution_text": null,
+      "url": "https://www.caltrain.com/developer-resources"
+    },
+    {
+      "identifier": "ca-capital-corridor-terms",
+      "name": "Capitol Corridor Terms",
+      "attribution_text": null,
+      "url": "https://www.capitolcorridor.org/developer_resources/#terms"
+    },
+    {
       "identifier": "trimet-tou",
       "name": "TriMet Terms of Use",
       "attribution_text": null,
@@ -1177,6 +1207,36 @@
       "spdx": null,
       "url": "https://nap.transportes.gob.es/api/Fichero/download/1132",
       "custom_license": "Licencia Datos"
+    },
+    {
+      "file": "us-ca_SF-bayarea.gtfs.zip",
+      "spdx": null,
+      "url": "https://www.bart.gov/dev/schedules/google_transit.zip",
+      "custom_license": "ca-bart-terms"
+    },
+    {
+      "file": "us-ca_SFMTA.gtfs.zip",
+      "spdx": null,
+      "url": "https://muni-gtfs.apps.sfmta.com/data/muni_gtfs-current.zip",
+      "custom_license": "ca-sfmta-terms"
+    },
+    {
+      "file": "us-ca_Caltrain.gtfs.zip",
+      "spdx": null,
+      "url": "https://data.trilliumtransit.com/gtfs/caltrain-ca-us/caltrain-ca-us.zip",
+      "custom_license": "ca-caltrain-terms"
+    },
+    {
+      "file": "us-ca_Capitolcorridor.gtfs",
+      "spdx": null,
+      "url": "https://www.capitolcorridor.org/googletransit/GTFS.zip",
+      "custom_license": "ca-capital-corridor-terms"
+    },
+    {
+      "file": "us-ca_Santa-Cruz-Metro.gtfs.zip",
+      "spdx": "CC-BY-4.0",
+      "url": "https://developer.scmetro.org/gtfs.zip",
+      "custom_license": null
     },
     {
       "file": "us_Amtrak.gtfs.zip",


### PR DESCRIPTION
# License Template / Lizenz Vorlage

- [X] I have read the license requirements in the [README](/README.md) and I am sure that my contribution is compliant with the license requirements.
- [X] I have checked my contribution for syntax errors

## Country / Land

US/California/ "NorCal" (North California)

## License / Lizenz

Various proprietary licenses
- BART: https://www.bart.gov/schedules/developers/developer-license-agreement
- Caltrain https://www.caltrain.com/developer-resources
- Capitol Corridor (Amtrak California)  https://www.capitolcorridor.org/developer_resources/#terms
- Santa Cruz Metro htps://developer.scmetro.or
- SFMTA https://www.sfmta.com/reports/gtfs-transit-data
- VTA (Archived) https://web.archive.org/web/20190704044857/http://www.vta.org/getting-around/gtfs-info/dev-terms-of-use

## Source / Quelle

See above section.


## Notes / Anmerkungen

I could not find the VTA license given that it is 404ing on their website. I am adding it either way for future use if it is ever added. If the VTA data source is added to the Transitous data feed, it can be used.

https://gtfs.vta.org

## Träwelling Issue Link (optional)

#14 