### PR TITLE
Washington State Agencies -> licenses.json

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -175,30 +175,6 @@
       "url": "https://transitdata.ridewta.com"
     }
     {
-      "identifier": "kcm-tdtu",
-      "name": "Metro Transit Data Terms of Use",
-      "attribution_text": null,
-      "url": "https://kingcounty.gov/en/dept/metro/rider-tools/mobile-and-web-apps#toc-transit-data-terms-of-use"
-    }
-    {
-      "identifier": "st-otd",
-      "name": "Sound Transit Data Terms of Use",
-      "attribution_text": null,
-      "url": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/transit-data-terms-use"
-    }
-    {
-      "identifier": "ct-open-tou",
-      "name": "Community Transit Open Data Terms of Use",
-      "attribution_text": null,
-      "url": "https://www.communitytransit.org/open-data"
-    }
-    {
-      "identifier": "kt-dua",
-      "name": "Kitsap Transit Developer User Agreement",
-      "attribution_text": null,
-      "url": "https://www.kitsaptransit.com/terms-and-conditions#developer"
-    }
-    {
       "identifier": "jta-tou",
       "name": "Jefferson Transit Authority Data Terms of Use",
       "attribution_text": null,
@@ -1237,54 +1213,6 @@
       "spdx": null,
       "url": "https://github.com/whatcomtrans/publicwtadata/raw/master/GTFS/wta_gtfs_latest.zip",
       "custom_license": "wta-data"
-    }
-    {
-      "file": "us-wa_Metro-Transit.gtfs.zip",
-      "spdx": null,
-      "url": "https://gtfs.sound.obaweb.org/prod/1_gtfs.zip",
-      "custom_license": "kcm-tdtu"
-    }
-    {
-      "file": "us-wa_Sound-Transit.gtfs.zip",
-      "spdx": null,
-      "url": "https://gtfs.sound.obaweb.org/prod/40_gtfs.zip",
-      "custom_license": "st-otd"
-    }
-    {
-      "file": "us-wa_Pierce-Transit.gtfs.zip",
-      "spdx": null,
-      "url": "https://gtfs.sound.obaweb.org/prod/3_gtfs.zip",
-      "custom_license": "st-otd"
-    }
-    {
-      "file": "us-wa_Intercity-Transit.gtfs.zip",
-      "spdx": null,
-      "url": "https://gtfs.sound.obaweb.org/prod/19_gtfs.zip",
-      "custom_license": "st-otd"
-    }
-    {
-      "file": "us-wa_Community-Transit.gtfs.zip",
-      "spdx": null,
-      "url": "https://www.communitytransit.org/docs/default-source/open-data/gtfs/current.zip?sfvrsn=1968d0e2_118",
-      "custom-license": "ct-open-tou"
-    }
-    {
-      "file": "us-wa_Everett-Transit.gtfs.zip",
-      "spdx": null,
-      "url:" "https://everett.mapstrat.com/current/google_transit.zip",
-      "custom-license": "st-otd"
-    }
-    {
-      "file": "us-wa_Washington-State-Ferries.gtfs.zip",
-      "spdx": null,
-      "url": "https://business.wsdot.wa.gov/Transit/csv_files/wsf/google_transit.zip",
-      "custom-license": "st-otd"
-    }
-    {
-      "file": "us-wa_Kitsap-Transit.gtfs.zip",
-      "spdx": null,
-      "url": "https://pride.kitsaptransit.com/gtfs/google_transit.zip",
-      "custom-license": "kt-dua"
     }
     {
       "file": "us-wa_Jefferson-Transit.gtfs.zip",

--- a/licenses.json
+++ b/licenses.json
@@ -168,6 +168,48 @@
       "attribution_text": null,
       "url": "https://developer.trimet.org/terms_of_use.shtml"
     }
+    {
+      "identifier": "wta-data",
+      "name": "WTA Transit Data",
+      "attribution_text": null,
+      "url": "https://transitdata.ridewta.com"
+    }
+    {
+      "identifier": "kcm-tdtu",
+      "name": "Metro Transit Data Terms of Use",
+      "attribution_text": null,
+      "url": "https://kingcounty.gov/en/dept/metro/rider-tools/mobile-and-web-apps#toc-transit-data-terms-of-use"
+    }
+    {
+      "identifier": "st-otd",
+      "name": "Sound Transit Data Terms of Use",
+      "attribution_text": null,
+      "url": "https://www.soundtransit.org/help-contacts/business-information/open-transit-data-otd/transit-data-terms-use"
+    }
+    {
+      "identifier": "ct-open-tou",
+      "name": "Community Transit Open Data Terms of Use",
+      "attribution_text": null,
+      "url": "https://www.communitytransit.org/open-data"
+    }
+    {
+      "identifier": "kt-dua",
+      "name": "Kitsap Transit Developer User Agreement",
+      "attribution_text": null,
+      "url": https://www.kitsaptransit.com/terms-and-conditions#developer"
+    }
+    {
+      "identifier": "jta-tou",
+      "name": "Jefferson Transit Authority Data Terms of Use",
+      "attribution_text": null,
+      "url": "https://jeffersontransit.com/DocumentCenter/View/146/Jefferson-Transit-Authority-Data-License-Agreement-and-Terms-of-Use-PDF"
+    }
+    {
+      "identifier": "sta-tou",
+      "name": "Spokane Transit Developer Terms of Use",
+      "attribution_text": null,
+      "url": "https://www.spokanetransit.com/developers-terms-of-use/"
+    }
   ],
   "sources": [
     {
@@ -1189,6 +1231,72 @@
       "spdx": null,
       "url": "https://developer.trimet.org/schedule/gtfs.zip",
       "custom_license": "trimet-tou"
+    }
+    {
+      "file": "us-wa_Whatcom-Transporation-Authority.gtfs.zip",
+      "spdx": null,
+      "url": "https://github.com/whatcomtrans/publicwtadata/raw/master/GTFS/wta_gtfs_latest.zip",
+      "custom_license": "wta-data"
+    }
+    {
+      "file": "us-wa_Metro-Transit.gtfs.zip",
+      "spdx": null,
+      "url": "https://gtfs.sound.obaweb.org/prod/1_gtfs.zip",
+      "custom_license": "kcm-tdtu"
+    }
+    {
+      "file": "us-wa_Sound-Transit.gtfs.zip",
+      "spdx": null,
+      "url": "https://gtfs.sound.obaweb.org/prod/40_gtfs.zip",
+      "custom_license": "st-otd"
+    }
+    {
+      "file": "us-wa_Pierce-Transit.gtfs.zip",
+      "spdx": null,
+      "url": "https://gtfs.sound.obaweb.org/prod/3_gtfs.zip",
+      "custom_license": "st-otd"
+    }
+    {
+      "file": "us-wa_Intercity-Transit.gtfs.zip",
+      "spdx": null,
+      "url": "https://gtfs.sound.obaweb.org/prod/19_gtfs.zip",
+      "custom_license": "st-otd"
+    }
+    {
+      "file": "us-wa_Community-Transit.gtfs.zip",
+      "spdx": null,
+      "url": "https://www.communitytransit.org/docs/default-source/open-data/gtfs/current.zip?sfvrsn=1968d0e2_118",
+      "custom-license": "ct-open-tou"
+    }
+    {
+      "file": "us-wa_Everett-Transit.gtfs.zip",
+      "spdx": null,
+      "url:" "https://everett.mapstrat.com/current/google_transit.zip",
+      "custom-license": "st-otd"
+    }
+    {
+      "file": "us-wa_Washington-State-Ferries.gtfs.zip",
+      "spdx": null,
+      "url": "https://business.wsdot.wa.gov/Transit/csv_files/wsf/google_transit.zip",
+      "custom-license": "st-otd"
+    }
+    {
+      "file": "us-wa_Kitsap-Transit.gtfs.zip",
+      "spdx": null,
+      "url": "https://pride.kitsaptransit.com/gtfs/google_transit.zip",
+      "custom-license": "kt-dua"
+    }
+    {
+      "file": "us-wa_Jefferson-Transit.gtfs.zip",
+      "spdx": null,
+      "url": "http://mjcaction.com/MJC_GTFS_Public/jefferson_google_transit.zip",
+      "custom_license": "jta-tou"
+    }
+    {
+      "file": "us-wa_Spokane-Transit.gtfs.zip",
+      "spdx": null,
+      "url": "https://www.spokanetransit.com/gtfs",
+      "custom_license": "sta-tou"
     }
   ]
 }

--- a/licenses.json
+++ b/licenses.json
@@ -177,7 +177,7 @@
     {
       "identifier": "jta-tou",
       "name": "Jefferson Transit Authority Data Terms of Use",
-      "attribution_text": null,
+      "attribution_text": "Transit scheduling, geographic, and real-time data provided by permission of Jefferson Transit Authority",
       "url": "https://jeffersontransit.com/DocumentCenter/View/146/Jefferson-Transit-Authority-Data-License-Agreement-and-Terms-of-Use-PDF"
     }
     {

--- a/licenses.json
+++ b/licenses.json
@@ -196,7 +196,7 @@
       "identifier": "kt-dua",
       "name": "Kitsap Transit Developer User Agreement",
       "attribution_text": null,
-      "url": https://www.kitsaptransit.com/terms-and-conditions#developer"
+      "url": "https://www.kitsaptransit.com/terms-and-conditions#developer"
     }
     {
       "identifier": "jta-tou",


### PR DESCRIPTION
Added Washington State agencies with readily available licenses.

# License Template / Lizenz Vorlage

- [x] I have read the license requirements in the [README](/README.md) and I am sure that my contribution is compliant with the license requirements.
- [x] I have checked my contribution for syntax errors

## Country / Land

United States/Washington

## License / Lizenz

WTA Public Data
Jefferson Transit Authority Data Terms of Use
Spokane Transit Developer Terms of Use

## Source / Quelle

https://transitdata.ridewta.com
https://jeffersontransit.com/DocumentCenter/View/146/Jefferson-Transit-Authority-Data-License-Agreement-and-Terms-of-Use-PDF
https://www.spokanetransit.com/developers-terms-of-use/

## Notes / Anmerkungen

Whatcom may be a little more vague than the rest due to it being on GitHub. However, it is labeled as public and Transitous did consider it as a valid source for conditions.

## Träwelling Issue Link (optional)

n/a
