### PR TITLE
Add license for BKK funicular, chairlift and Üröm kisbusz

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -1327,6 +1327,24 @@
       "spdx": "CC-BY-4.0",
       "url": "https://api.smartdatanet.it/api/Servizioprogrammatodeltrasportopubblicoregionepiemonteautobus_22942/attachment/22941/1/GTFS_BUS_IT_PIE.zip",
       "custom_license": null
+    },
+    {
+      "file": "hu_bkk-funicular.gtfs.zip",
+      "spdx": "GPL-3.0-only",
+      "url": "https://gy-mate.hu/gtfs/gtfs_hu_funicular.zip",
+      "custom_license": null
+    },
+    {
+      "file": "hu_bkk-chairlift.gtfs.zip",
+      "spdx": "GPL-3.0-only",
+      "url": "https://gy-mate.hu/gtfs/gtfs_hu_chairlift.zip",
+      "custom_license": null
+    },
+    {
+      "file": "hu_urom.gtfs.zip",
+      "spdx": "GPL-3.0-only",
+      "url": "https://gy-mate.hu/gtfs/gtfs_hu_urom.zip",
+      "custom_license": null
     }
   ]
 }


### PR DESCRIPTION
# License Template / Lizenz Vorlage

- [x] I have read the license requirements in the [README](/README.md) and I am sure that my contribution is compliant with the license requirements.
- [x] I have checked my contribution for syntax errors

## Country / Land

Hungary

## License / Lizenz

GNU General Public License v3.0 
https://spdx.org/licenses/GPL-3.0-only.html

## Source / Quelle

https://github.com/gy-mate/gtfs-feeds?tab=GPL-3.0-1-ov-file#readme

## Notes / Anmerkungen

This is about the GTFS feeds for BKK funicular, BKK chairlift and the Üröm kisbusz, all published by @gy-mate
